### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,13 @@
 /yarn-error.log
 
 .byebug_history
+
+# Rails assets
+log/*.log
+public/assets/*
+public/cache/*
+public/images/themes/*
+public/javascripts/cache/*
+public/stylesheets/cache/*
+public/themes
+public/files/*


### PR DESCRIPTION
Ignore compiled assets (Affects production server only).
The production server will compile all static assets to the `public/assets` folder in order to quickly serve static assets. 
Currently, these types of files are not ignored, but should be.