### PR TITLE
Open source the repository

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-service_name: travis-pro
-repo_token: VG74CYEhev6ZKONJV1kDGHebwEibT2uPB

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Chase Schachenman, Geroge Black, Jack Shelton, Maddy Janick, Peter Carey, and Rosie Brezynski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BadgerNet
 
 [![Build Status](https://travis-ci.com/Chaseshak/BadgerNet.svg?token=y8dTrJkpQLTEPjpNhoQh&branch=master)](https://travis-ci.com/Chaseshak/BadgerNet)
-[![Coverage Status](https://coveralls.io/repos/github/Chaseshak/BadgerNet/badge.svg?t=waLDpl)](https://coveralls.io/github/Chaseshak/BadgerNet)
+[![Coverage Status](https://coveralls.io/repos/github/Chaseshak/BadgerNet/badge.svg?branch=master)](https://coveralls.io/github/Chaseshak/BadgerNet?branch=master)
 
 BadgerNet is a software that was developed for UW Athletics teams as a platform for coaches
 to share information with their athletes and communicate effectively. The current system

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Code coverage data can be viewed on [coveralls](https://coveralls.io/github/Chas
 
 ### Test Structure
 
-All tests are contained in the `spec/` folder. There are several folders nested underneath this directory.
+All tests are contained in the `spec/` folder. There are several folders nested underneath this directory. 
 
 `controllers/` contains unit tests for all application controllers
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ $ bundle exec rails s
 ### Run entire test suite
 `$ bundle exec rspec`
 
+### Coverage Data
+
+Code coverage data can be viewed on [coveralls](https://coveralls.io/github/Chaseshak/BadgerNet)! This will give you line by line coverage information for each file.
+
 ### Test Structure
 
 All tests are contained in the `spec/` folder. There are several folders nested underneath this directory.


### PR DESCRIPTION
This MIT License allows any distribution and modification of this software under any purposes and absolves the creators (us) from any liability of distributed use of software.

I consulted with @rbrezynski on this, but I think we should open-source the code/project. This will allow us to:
* Display the project in our portfolios
* The athletic department to use any of this code should they decide to update BadgerNet
* Travis CI and Coveralls data will be available for everyone without signing in which will help with testing and clarity of continuous integration checks.

I figured we would not actually implement this in its entirety in order for it to be functional enough to use in a production environment.

Comments/Questions are welcome!