### PR TITLE
Remove profile image feature

### DIFF
--- a/app/assets/stylesheets/base/navigation.scss
+++ b/app/assets/stylesheets/base/navigation.scss
@@ -10,7 +10,7 @@ $navbar-gradient-end: #28A5F5;
 
 .navbar-container {
     padding: 0 1.25em 0 1.25em;
-    height: 3.75em;
+    height: 3.5em;
     width: 100%;
     display: flex;
     align-items: center;
@@ -72,19 +72,7 @@ $navbar-gradient-end: #28A5F5;
 
 .navbar-profile {
     flex-grow: 0;
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    font-family: $default-body-font;
     color: white;
-
-    img {
-        margin: 0 0 0 1em;
-        width: 2.5em;
-        height: 2.5em;
-        border: 3px solid rgba(255,255,255, 0.8);
-        border-radius: 100%;
-    }
 
     a {
         text-decoration: none;

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -16,7 +16,6 @@
         </div>
         <div class="navbar-profile">
             <span>Welcome, <%= defined?(current_user.first_name) ? current_user.first_name : 'user' %><br><a href="/settings">Settings</a> – <%= link_to('Logout', destroy_user_session_path, method: :delete) %></span>
-            <img src="http://lorempixel.com/200/200" />
         </div>
     </div>
 </nav>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,22 +1,10 @@
-<div class="main">
-<div class="container">
-  <h1>Settings</h1>
-
-  <%= form_for @user, url: "/settings/#{@user.id}", method: :put do |f| %>
-    <br>
-    <%= f.label "First Name" %>
-    <%= f.text_field :first_name, class: 'input' %>
-    <%= f.label "Last Name" %>
-    <%= f.text_field :last_name, class: 'input' %>
-    <%= f.label "Phone Number" %>
-    <%= f.text_field :phone, class: 'input' %>
-    <br>
-    <%= f.submit "Update Profile Information", class: 'button-primary' %>
-  <% end %>
-
-  <p>Profile Picture</p>
-  <br>
-  <img src="http://lorempixel.com/200/200" />
-
-</div>
-</div>
+<h1>Settings</h1>
+<%= form_for @user, url: "/settings/#{@user.id}", method: :put do |f| %><br>
+<%= f.label "First Name" %>
+<%= f.text_field :first_name, class: 'input' %>
+<%= f.label "Last Name" %>
+<%= f.text_field :last_name, class: 'input' %>
+<%= f.label "Phone Number" %>
+<%= f.text_field :phone, class: 'input' %><br>
+<%= f.submit "Update Profile Information", class: 'button-primary' %>
+<% end %>


### PR DESCRIPTION
It was agreed upon that the profile image feature adds unnecessary complexity, and doesn't serve any practical purpose within our application. 

The placeholder images have been removed from the settings page and the navigation bar.