### PR TITLE
Do not allow user to see themselves in permissions

### DIFF
--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -4,7 +4,7 @@ class PermissionsController < ApplicationController
   before_action :coach?
 
   def index
-    @users = User.all
+    @users = User.where.not id: current_user.id
   end
 
   def create

--- a/spec/features/permissions_page_spec.rb
+++ b/spec/features/permissions_page_spec.rb
@@ -31,7 +31,8 @@ RSpec.feature 'Visiting the permissions page', type: :feature do
     end
 
     scenario 'Deleting a user should remove their information from the table' do
-      expect { page.all('input', class: 'button-danger')[1].click }
+      FactoryGirl.create(:athlete_user, email: 'test1@example.com')
+      expect { page.all('input', class: 'button-danger')[0].click }
         .to change { User.count }.by(-1)
     end
 


### PR DESCRIPTION
This prevents them from downgrading themselves from the coach role and accidentally deleting themselves from the system.