### PR TITLE
Bug fixes

### DIFF
--- a/app/assets/stylesheets/schedule.scss
+++ b/app/assets/stylesheets/schedule.scss
@@ -86,5 +86,5 @@ $event-block-color: #2979ad;
 
 .single-event-label {
     color: white;
-    font-size: 0.85em;
+    font-size: 0.75em;
 }

--- a/app/views/announcement/_new.html.erb
+++ b/app/views/announcement/_new.html.erb
@@ -2,7 +2,7 @@
   <%= f.label "Send via" %>
   <div class="check-box-group">
     <div class="check-box-group-item">
-      <%= f.check_box :email%>  <%# figure out how to do validation %>
+      <%= f.check_box :email%> 
       <%= f.label :email, 'Email'%>
     </div>
     <div class="check-box-group-item">
@@ -12,9 +12,9 @@
   </div>
   <%= render 'shared/roles' %>
   <%= f.label :title, 'Title'%>
-  <%= f.text_field :title %>
+  <%= f.text_field :title, maxlength: 30 %>
   <%= f.label 'Message' %>
-  <%= f.text_area :content, required: true %>
+  <%= f.text_area :content, required: true, maxlength: 7500%>
   <div style="margin-top:1.5em;text-align:right;">
     <button class="button-default" onclick="toggleModal('new-announcement')">Cancel</button>
     <%= f.submit "Send Announcement", class: "button-primary"%>

--- a/app/views/announcement/_show.html.erb
+++ b/app/views/announcement/_show.html.erb
@@ -10,6 +10,6 @@
             send_method = ', sent via SMS'
         end
     %>
-    <p class="announcement-tagline"><%= announcement.created_at.strftime("%B %-d at %-I%p") %><%= send_method %></p>
+    <p class="announcement-tagline"><%= announcement.created_at.in_time_zone('Central Time (US & Canada)').strftime("%B %-d at %-I%p") %><%= send_method %></p>
     <p class="announcement-content"><%= announcement.content %>
 </div>

--- a/app/views/announcement/admin_index.html.erb
+++ b/app/views/announcement/admin_index.html.erb
@@ -18,10 +18,10 @@
                 <% @announcements.each_with_index do |announcement, index| %>
                     <tr>
                         <td><%= announcement.title%></td>
-                        <td><%= (announcement.created_at).strftime("%b %-d, %Y at %-I:%M%p") %></td>
+                        <td><%= (announcement.created_at).in_time_zone('Central Time (US & Canada)').strftime("%b %-d, %Y at %-I:%M%p") %></td>
                         <td>
                             <% if announcement.sms && announcement.email %>
-                                <%= 'SMS, Email' %>
+                                <%= 'Email, SMS' %>
                             <% elsif announcement.sms%>
                                 <%= 'SMS' %>
                             <% elsif announcement.email%>

--- a/app/views/announcement/index.html.erb
+++ b/app/views/announcement/index.html.erb
@@ -15,10 +15,10 @@
                 <% @announcements.each_with_index do |announcement, index| %>
                     <tr>
                         <td><%= announcement.title%></td>
-                        <td><%= (announcement.created_at).strftime("%b %-d, %Y at %-I:%M%p") %></td>
+                        <td><%= (announcement.created_at).in_time_zone('Central Time (US & Canada)').strftime("%b %-d, %Y at %-I:%M%p") %></td>
                         <td>
                             <% if announcement.sms && announcement.email %>
-                                <%= 'SMS, Email' %>
+                                <%= 'Email, SMS' %>
                             <% elsif announcement.sms%>
                                 <%= 'SMS' %>
                             <% elsif announcement.email%>

--- a/app/views/documents/_new.html.erb
+++ b/app/views/documents/_new.html.erb
@@ -1,8 +1,8 @@
 <%= form_for @document, url: { action: "create" } do |f| %>
     <%= f.label :name %>
-    <%= f.text_field :name,:required => 'required' %>
+    <%= f.text_field :name,required: true, maxlength: 30 %>
     <%= f.label :attachment %>
-    <%= f.file_field :attachment,:required => 'required' %>
+    <%= f.file_field :attachment,required: true %>
     <%= render 'shared/roles' %>
     <div style="margin-top:1.5em;text-align:right;">
         <button class="button-default" onclick="toggleModal('new-document')">Cancel</button>

--- a/app/views/documents/admin_index.html.erb
+++ b/app/views/documents/admin_index.html.erb
@@ -16,7 +16,7 @@
             <% @documents.each do |document| %>
             <tr>
                 <td><%= document.name %></td>
-                <td><%= document.created_at.strftime("%b %-d, %Y at %-I:%M%p") %></td>
+                <td><%= document.created_at.in_time_zone('Central Time (US & Canada)').strftime("%b %-d, %Y at %-I:%M%p") %></td>
                 <td>
                     <%= link_to 'Download Document', document.attachment_url, class: 'button-primary' %>
                     <%= button_to "Delete",  document, method: :delete, class: "button-danger", confirm: "Are you sure that you wish to delete #{document.name}?" %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -13,7 +13,7 @@
             <% @documents.each do |document| %>
                 <tr>
                     <td><%= document.name %></td>
-                    <td><%= document.created_at.strftime("%b %-d, %Y at %-I:%M%p") %></td>
+                    <td><%= document.created_at.in_time_zone('Central Time (US & Canada)').strftime("%b %-d, %Y at %-I:%M%p") %></td>
                     <td><%= link_to 'Download Document', document.attachment_url, class: 'button-primary' %></td>
                 </tr>
             <% end %>

--- a/app/views/home/_announcement_block.html.erb
+++ b/app/views/home/_announcement_block.html.erb
@@ -1,7 +1,7 @@
 <div class="info-block-wrapper">
     <div class="info-block">
-        <h2>Recent Announcements</h2>
-        <table style="margin-top:1em;">
+    <h2><a href="announcement">Recent Announcements</a></h2>
+    <table style="margin-top:1em;">
             <tbody>
                 <% @announcements.each_with_index do |announcement, index| %>
                     <tr>

--- a/app/views/home/_announcement_block.html.erb
+++ b/app/views/home/_announcement_block.html.erb
@@ -1,6 +1,6 @@
 <div class="info-block-wrapper">
     <div class="info-block">
-    <h2><a href="announcement">Recent Announcements</a></h2>
+    <h2>Recent Announcements</h2>
     <table style="margin-top:1em;">
             <tbody>
                 <% @announcements.each_with_index do |announcement, index| %>
@@ -20,5 +20,7 @@
                 <% end %>
             </tbody>
         </table>
+        <button class="link-emphasized" onclick="window.location.href='announcement';">View More</button>
     </div>
+    
 </div>

--- a/app/views/home/_announcement_block.html.erb
+++ b/app/views/home/_announcement_block.html.erb
@@ -6,7 +6,7 @@
                 <% @announcements.each_with_index do |announcement, index| %>
                     <tr>
                         <td><%= announcement.title %></td>
-                        <td><%= announcement.updated_at.strftime("%b %-d, %Y")%></td>
+                        <td><%= announcement.updated_at.in_time_zone('Central Time (US & Canada)').strftime("%b %-d, %Y")%></td>
                         <td>
                             <button class="button-primary" onclick="toggleModal('show-announcement-<%= index %>')">View</button>
                             <div class="modal hidden" id="show-announcement-<%= index %>">

--- a/app/views/home/_document_block.html.erb
+++ b/app/views/home/_document_block.html.erb
@@ -1,6 +1,6 @@
 <div class="info-block-wrapper">
     <div class="info-block">
-    <h2><a href="documents">Recent Documents</a></h2>
+    <h2>Recent Documents</h2>
     <table style="margin-top:1em;">
             <tbody>
                 <% @documents.each do |document| %>
@@ -12,5 +12,6 @@
                 <% end %>
             </tbody>
         </table>
+        <button class="link-emphasized" onclick="window.location.href='documents';">View More</button>
     </div>
 </div>

--- a/app/views/home/_document_block.html.erb
+++ b/app/views/home/_document_block.html.erb
@@ -6,7 +6,7 @@
                 <% @documents.each do |document| %>
                 <tr>
                     <td><%= document.name %></td>
-                    <td><%= document.created_at.strftime("%b %-d, %Y") %></td>
+                    <td><%= document.created_at.in_time_zone('Central Time (US & Canada)').strftime("%b %-d, %Y") %></td>
                     <td><%= link_to 'Download Document', document.attachment_url, class: 'button-primary' %></td>
                 </tr>
                 <% end %>

--- a/app/views/home/_document_block.html.erb
+++ b/app/views/home/_document_block.html.erb
@@ -1,7 +1,7 @@
 <div class="info-block-wrapper">
     <div class="info-block">
-    <h2>Recent Documents</h2>
-        <table style="margin-top:1em;">
+    <h2><a href="documents">Recent Documents</a></h2>
+    <table style="margin-top:1em;">
             <tbody>
                 <% @documents.each do |document| %>
                 <tr>

--- a/app/views/schedule/_events_calendar.html.erb
+++ b/app/views/schedule/_events_calendar.html.erb
@@ -21,7 +21,7 @@
             <% else %>
                 <% @schedule.events_on_day(i).each do |event| %>
                 <div class="single-event" style="transform:translateY(<%= event_block_offset(event) %>px);height:<%= event_block_height(event) %>px">
-                    <span class="single-event-label"><%= event.name %></span>
+                    <span class="single-event-label"><%= event.name.truncate(15) %></span>
                 </div>
                 <% end %>
             <% end %>

--- a/app/views/schedule/_events_calendar.html.erb
+++ b/app/views/schedule/_events_calendar.html.erb
@@ -21,7 +21,7 @@
             <% else %>
                 <% @schedule.events_on_day(i).each do |event| %>
                 <div class="single-event" style="transform:translateY(<%= event_block_offset(event) %>px);height:<%= event_block_height(event) %>px">
-                    <span class="single-event-label"><%= event.name.truncate(15) %></span>
+                    <span class="single-event-label"><%= event.name.truncate(20) %></span>
                 </div>
                 <% end %>
             <% end %>

--- a/app/views/schedule/_events_table.html.erb
+++ b/app/views/schedule/_events_table.html.erb
@@ -7,7 +7,7 @@
             <% if @schedule.event %>
             <% @schedule.event.each do |event| %>
                 <tr>
-                    <td><%= event.name %></td>
+                    <td><%= event.name.truncate(50) %></td>
                     <td><%= "#{event.start_time.strftime("%I:%M%p")} - #{event.end_time.strftime("%I:%M%p")}" %></td>
                     <td><%= event.days_as_string %></td>
                     <td style="text-align:right;">


### PR DESCRIPTION
#96: timezones for announcements and documents
#89: limits on announcement title, announcement body, document title. Truncates event title in calendar view
#103: view more button links on homepage